### PR TITLE
Make the xml-rpc client capable of basic-auth and insecure https.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 lib/*.jar
+lib/dev
+.lein-deps-sum

--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
   :dependencies [[org.clojure/clojure "[1.2.1],[1.3.0]"]
                  [org.clojure/data.zip "0.1.0"]
                  [org.clojure/algo.monads "0.1.1-SNAPSHOT"]
-                 [clj-http "0.1.3"]
+                 [clj-http "0.2.7"]
                  [commons-codec "1.4"]
                  [clj-time "0.3.1"]
                  [commons-lang "2.6"]]
-  :dev-dependencies [[ring/ring-jetty-adapter "0.3.11"]
+  :dev-dependencies [[ring/ring-jetty-adapter "1.0.1"]
                      [marginalia "0.7.0-SNAPSHOT"]
                      [lein-marginalia "0.6.1"]])

--- a/src/necessary_evil/core.clj
+++ b/src/necessary_evil/core.clj
@@ -47,14 +47,19 @@
 
 ;; client functions
 
+(defn- make-headers
+  [body opts]
+  (merge  {:body body
+           :content-type "text/xml;charset=UTF-8"}
+          opts))
+
 (defn call
   "Does a syncronous http request to the server and method provided."
-  [endpoint-url method-name & args]
-  (let [call (methodcall/methodcall method-name args)
-        body (-> call methodcall/unparse emit with-out-str)]
-    (-> (http/post endpoint-url {:body body
-                                 :content-type "text/xml;charset=UTF-8"})
-        :body
-        to-xml
-        methodresponse/parse)))
+  ([endpoint-url method-name http-opts & args]
+     (let [call (methodcall/methodcall method-name args)
+           body (-> call methodcall/unparse emit with-out-str)]
+       (-> (http/post endpoint-url (make-headers body http-opts))
+           :body
+           to-xml
+           methodresponse/parse))))
 


### PR DESCRIPTION
NOTE: This breaks backwards compatibility, though there may be a way
to modify my changes so that backwards compatibility is maintained.

This  also uses a newer version of clj-http and ring-jetty-adapter.
