### PR TITLE
Dependencies updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
-lib/*.jar
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-repl-history

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+lib/*.jar
 /target
 /lib
 /classes

--- a/README.markdown
+++ b/README.markdown
@@ -153,6 +153,10 @@ The following the main API functions that you will use as a consumer of the libr
  * `necessary-evil.fault/fault?` — Predicate that tests a value for being a Fault record.
  * `necessary-evil.fault/attempt-all` — A comprehension form to make it easier to work with potentially Fault returning functions. For more detail on this macro see my [Error Monads](http://brehaut.net/blog/2011/error_monads#attempt_all) and [Error Monads Revisited ](http://brehaut.net/blog/2011/error_monads_revisited) blog posts.
 
+## Changes from 2.0.0 to 2.0.1
+
+ * Updated dependencies to newer versions
+
 ## Changes from 1.2.2 to 2.0.0
 
 Despite the big jump in version numbers relatively small changes have occured.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject necessary-evil "2.0.0"
+(defproject necessary-evil "2.0.1"
   :description "An implementation of XML-RPC for the Clojure Ring HTTP stack"
 
   :url "https://github.com/brehaut/necessary-evil/"
@@ -6,12 +6,12 @@
   :license {:name "Eclipse Public License",
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   
-  :dependencies {org.clojure/clojure "1.4.0",
-                 org.clojure/data.zip "0.1.0",
-                 org.clojure/algo.monads "0.1.3-20120910.070123-6", ; lock to a specific snapshot
+  :dependencies {org.clojure/clojure "1.7.0",
+                 org.clojure/data.zip "0.1.1",
+                 org.clojure/algo.monads "0.1.5",
                  clj-http "0.5.8",
-                 commons-codec "1.4",
-                 clj-time "0.4.4",
+                 commons-codec "1.9",
+                 clj-time "0.9.0",
                  commons-lang "2.6"}
   :profiles {:dev {:dependencies {ring/ring-jetty-adapter "1.0.1", marginalia "0.7.0-SNAPSHOT"}
                    :plugins {lein-marginalia "0.7.0-SNAPSHOT"}}}


### PR DESCRIPTION
```
$ lein deps :tree
 [clj-http "0.5.8"]
   [cheshire "4.0.3"]
     [com.fasterxml.jackson.core/jackson-core "2.0.6"]
     [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.0.6"]
   [commons-io "2.4"]
   [crouton "0.1.1"]
     [org.jsoup/jsoup "1.7.1"]
   [org.apache.httpcomponents/httpclient "4.2.2"]
     [commons-logging "1.1.1"]
   [org.apache.httpcomponents/httpcore "4.2.2"]
   [org.apache.httpcomponents/httpmime "4.2.2"]
   [slingshot "0.10.3"]
 [clj-time "0.9.0"]
   [joda-time "2.6"]
 [clojure-complete "0.2.3"]
 [commons-codec "1.9"]
 [commons-lang "2.6"]
 [criterium "0.4.1"]
 [marginalia "0.7.0-20120306.003817-18"]
   [hiccup "0.3.7"]
   [org.clojure/tools.cli "0.2.1"]
   [org.clojure/tools.namespace "0.1.1"]
     [org.clojure/java.classpath "0.1.1"]
   [org.markdownj/markdownj "0.3.0-1.0.2b4"]
 [org.clojure/algo.monads "0.1.5"]
   [org.clojure/tools.macro "0.1.0"]
 [org.clojure/clojure "1.7.0"]
 [org.clojure/data.zip "0.1.1"]
 [org.clojure/tools.nrepl "0.2.3"]
 [ring/ring-jetty-adapter "1.0.1"]
   [org.mortbay.jetty/jetty-util "6.1.25"]
   [org.mortbay.jetty/jetty "6.1.25"]
     [org.mortbay.jetty/servlet-api "2.5-20081211"]
   [ring/ring-core "1.0.1"]
     [commons-fileupload "1.2.1"]
     [javax.servlet/servlet-api "2.5"]
   [ring/ring-servlet "1.0.1"]
```
