### PR TITLE
Fix compatibility with Clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   
   :dependencies {org.clojure/clojure "1.7.0",
                  org.clojure/data.zip "0.1.1",
-                 org.clojure/algo.monads "0.1.5",
+                 org.clojure/algo.monads "0.1.6",
                  clj-http "0.5.8",
                  commons-codec "1.9",
                  clj-time "0.9.0",


### PR DESCRIPTION
With version "0.1.5" of org.clojure/algo.monads Clojure 1.9.0-alpha12 fails to load the necessary-evil.fault namespace with:
CompilerException clojure.lang.ExceptionInfo: Call to clojure.core/defn did not conform to spec:
In: [0] val: clojure.algo.monads/m+m-join+m fails spec: :clojure.core.specs/defn-args at: [:args :name] predicate: simple-symbol?
:clojure.spec/args  (clojure.algo.monads/m+m-join+m [m-bind m-result m-zero m-plus m](clojure.tools.macro/with-symbol-macros %28m-bind m identity%29))
 #:clojure.spec{:problems [{:path [:args :name], :pred simple-symbol?, :val clojure.algo.monads/m+m-join+m, :via [:clojure.core.specs/defn-args :clojure.core.specs/defn-args], :in [0]}], :args (clojure.algo.monads/m+m-join+m [m-bind m-result m-zero m-plus m](clojure.tools.macro/with-symbol-macros %28m-bind m identity%29))}, compiling:(clojure/algo/monads.clj:248:1)
